### PR TITLE
Transitive rebinding

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,12 @@ Quickstart guide
 
 To get started with `ndscan`, first prepare a Python 3.10+ environment with
 ARTIQ as usual (Nix, Poetry or some form of virtualenv is recommended).
-**This development version (`master` branch) depends on a recent ARTIQ 8
-version (yet unreleased) due to backwards-incompatible changes in the latter.
-If you still need to use an older ARTIQ version, please see the
+**This development version (`master` branch) depends on ARTIQ 8+ due to
+backwards-incompatible changes in ARTIQ's APIs. If you still need to use an
+older ARTIQ version, please see the
 [release-0.3](https://github.com/OxfordIonTrapGroup/ndscan/tree/release-0.3)
-branch instead.**
+branch instead** (or be prepared to resolve some issues yourself by
+selectively reverting a few changes).
 
 Once your environment is set up, install this package. For example, to use
 `ndscan` directly from the Git checkout without directly using the

--- a/ndscan/experiment/fragment.py
+++ b/ndscan/experiment/fragment.py
@@ -61,8 +61,7 @@ class Fragment(HasEnvironment):
         self._free_params = OrderedDict()
 
         #: Maps own attribute name to the ParamHandles of the rebound parameters in
-        #: their original subfragment (currently always only one, as there is only a
-        #: rebinding API that targets single paths).
+        #: their original subfragment.
         self._rebound_subfragment_params = dict()
 
         #: List of (param, store) tuples of parameters set to their defaults after

--- a/ndscan/experiment/fragment.py
+++ b/ndscan/experiment/fragment.py
@@ -370,7 +370,7 @@ class Fragment(HasEnvironment):
         param = param_class(fqn, description, *args, **kwargs)
         self._free_params[name] = param
 
-        handle = param.HandleType(self, name)
+        handle = param.HandleType(self, name, param)
         setattr(self, name, handle)
         return handle
 
@@ -419,7 +419,7 @@ class Fragment(HasEnvironment):
         init_params["fqn"] = self.fqn + "." + name
         new_param = template_param.__class__(**init_params)
         self._free_params[name] = new_param
-        new_handle = new_param.HandleType(self, name)
+        new_handle = new_param.HandleType(self, name, new_param)
         setattr(self, name, new_handle)
         return new_handle
 
@@ -548,8 +548,13 @@ class Fragment(HasEnvironment):
 
         del self._free_params[param_name]
 
-        source.owner._rebound_subfragment_params.setdefault(source.name, []).extend(
-            self._get_all_handles_for_param(param_name))
+        handles = self._get_all_handles_for_param(param_name)
+
+        for handle in handles:
+            handle.parameter = source.parameter
+
+        source.owner._rebound_subfragment_params.setdefault(source.name,
+                                                            []).extend(handles)
 
         return param
 

--- a/ndscan/experiment/fragment.py
+++ b/ndscan/experiment/fragment.py
@@ -757,7 +757,7 @@ class ExpFragment(Fragment):
         (see ``artiq.language.environment.Experiment.prepare``).
 
         This is invoked only once per (sub)scan, after :meth:`Fragment.build_fragment`
-        but before :meth:`.host_setup`. At this point, parameters, datasets and devices
+        but before :meth:`host_setup`. At this point, parameters, datasets and devices
         can be accessed, but devices must not yet be.
 
         For top-level scans, this can (and will) be executed in the `prepare` scheduler

--- a/ndscan/experiment/parameters.py
+++ b/ndscan/experiment/parameters.py
@@ -238,11 +238,6 @@ class ParamHandle:
         self._changed_after_use = True
 
     @portable
-    def _change_cb(self):
-        # Once transform lambdas are supported, handle them here.
-        self._changed_after_use = True
-
-    @portable
     def changed_after_use(self) -> bool:
         return self._changed_after_use
 

--- a/ndscan/experiment/parameters.py
+++ b/ndscan/experiment/parameters.py
@@ -49,12 +49,14 @@ class ParamStore:
         self._value = self.coerce(value)
 
     @host_only
-    def register_handle(self, handle):
+    def _register_handle(self, handle):
+        # Private to this module (part of the handle change_after_used tracking).
         self._handles.append(handle)
         self._notify = self._notify_handles
 
     @host_only
-    def unregister_handle(self, handle):
+    def _unregister_handle(self, handle):
+        # Private to this module (part of the handle change_after_used tracking).
         self._handles.remove(handle)
 
         if not self._handles:
@@ -262,8 +264,8 @@ class ParamHandle:
         """
         """
         if self._store:
-            self._store.unregister_handle(self)
-        store.register_handle(self)
+            self._store._unregister_handle(self)
+        store._register_handle(self)
         self._store = store
         self._changed_after_use = True
 

--- a/ndscan/experiment/parameters.py
+++ b/ndscan/experiment/parameters.py
@@ -10,10 +10,13 @@
 from artiq.language import host_only, portable, units
 from enum import Enum
 from numpy import int32
-from typing import Any
+from typing import Any, TYPE_CHECKING
 from ..utils import eval_param_default, GetDataset
 
 __all__ = ["FloatParam", "IntParam", "StringParam", "BoolParam", "EnumParam"]
+
+if TYPE_CHECKING:
+    from .fragment import Fragment
 
 
 class InvalidDefaultError(ValueError):

--- a/ndscan/experiment/parameters.py
+++ b/ndscan/experiment/parameters.py
@@ -7,7 +7,6 @@
 # but to hang our heads in shame and manually instantiate the parameter handling
 # machinery for all supported value types, in particular to handle cases where e.g.
 # both an int and a float parameter is scanned at the same time.
-
 from artiq.language import host_only, portable, units
 from enum import Enum
 from numpy import int32
@@ -213,12 +212,15 @@ class ParamHandle:
     :param owner: The owning fragment.
     :param name: The name of the attribute in the owning fragment bound to this
         object.
+    :param parameter: The parameter associated with this handle. The
+        :attr:`~.ParamHandle.parameter` attribute points to the parameter currently
+        associated with this handle, tracking binding of the parameter.
     """
-    def __init__(self, owner: Any, name: str):
-        # `owner` will typically be a Fragment instance; no type hint to avoid circular
-        # dependency.
+    def __init__(self, owner: "Fragment", name: str, parameter):
         self.owner = owner
         self.name = name
+        self.parameter = parameter
+
         assert name.isidentifier(), ("ParamHandle name should be the identifier it is "
                                      "referred to as in the owning fragment.")
 

--- a/ndscan/experiment/result_channels.py
+++ b/ndscan/experiment/result_channels.py
@@ -291,6 +291,7 @@ class NumericChannel(ResultChannel):
     def push(self, raw_value) -> None:
         """
         """
+        self._value_pushed = True
         self._last_value = raw_value
         self._push(raw_value)
 

--- a/ndscan/experiment/result_channels.py
+++ b/ndscan/experiment/result_channels.py
@@ -2,7 +2,7 @@
 Result handling building blocks.
 """
 
-from artiq.language import HasEnvironment, portable, rpc
+from artiq.language import HasEnvironment, kernel, portable, rpc
 import artiq.language.units
 from typing import Any
 from .utils import dump_json
@@ -280,8 +280,13 @@ class NumericChannel(ResultChannel):
         self._value_pushed: bool = False
         self._last_value = self._coerce_to_type(0)
 
-    @portable
+    @kernel
     def get_last(self):
+        """ Returns the last value pushed to this result channel.
+
+        This method is a workaround for limitations of ARTIQ python, which make it
+        impractical to extract values from the sinks without going through RPCs.
+        """
         if not self._value_pushed:
             raise RuntimeError("No value pushed to channel")
 

--- a/ndscan/experiment/result_channels.py
+++ b/ndscan/experiment/result_channels.py
@@ -2,7 +2,7 @@
 Result handling building blocks.
 """
 
-from artiq.language import HasEnvironment, rpc
+from artiq.language import HasEnvironment, portable, rpc
 import artiq.language.units
 from typing import Any
 from .utils import dump_json
@@ -276,6 +276,29 @@ class NumericChannel(ResultChannel):
                                    "the scale manually".format(unit))
         self.scale = scale
         self.unit = unit
+
+        self._value_pushed: bool = False
+        self._last_value = self._coerce_to_type(0)
+
+    @portable
+    def get_last(self):
+        if not self._value_pushed:
+            raise RuntimeError("No value pushed to channel")
+
+        return self._last_value
+
+    @portable
+    def push(self, raw_value) -> None:
+        """
+        """
+        self._last_value = raw_value
+        self._push(raw_value)
+
+    @rpc(flags={"async"})
+    def _push(self, raw_value) -> None:
+        """
+        """
+        super().push(raw_value)
 
     def describe(self) -> dict[str, Any]:
         """"""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ requires = ["poetry-core>=1.0.0", "poetry-dynamic-versioning"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poe.tasks]
+docs = "make -C $POE_ROOT/docs html"
 fmt = "yapf -i -r examples ndscan test"
 fmt-test = "yapf -d -r examples ndscan test"
 lint = "flake8 examples ndscan test"

--- a/test/test_experiment_default_analysis.py
+++ b/test/test_experiment_default_analysis.py
@@ -6,9 +6,10 @@ from ndscan.experiment import parameters
 
 class CustomAnalysisTestCase(unittest.TestCase):
     def test_axis_matching(self):
-        foo = parameters.FloatParamHandle(None, "foo")
+        param = parameters.FloatParam("", "", 0.)
+        foo = parameters.FloatParamHandle(None, "foo", param)
         foo.set_store(parameters.FloatParamStore(("Fragment.foo", "*"), 0.0))
-        bar = parameters.FloatParamHandle(None, "bar")
+        bar = parameters.FloatParamHandle(None, "bar", param)
         bar.set_store(parameters.FloatParamStore(("Fragment.bar", "*"), 1.0))
 
         def make_axes(*axes):

--- a/test/test_experiment_entrypoint.py
+++ b/test/test_experiment_entrypoint.py
@@ -115,7 +115,7 @@ class FragmentScanExpCase(HasEnvironmentCase):
         for i in range(len(timestamps)):
             prev = 0.0 if i == 0 else timestamps[i - 1]
             cur = timestamps[i]
-            self.assertGreater(cur, prev)
+            self.assertGreaterEqual(cur, prev)
             # Timestamps are in seconds, so this is a _very_ conservative bound on
             # running the test loop in-process (which will take much less than a
             # millisecond).

--- a/test/test_experiment_parameters.py
+++ b/test/test_experiment_parameters.py
@@ -62,6 +62,7 @@ class GenericBase:
             fqn = next(iter(schemata.keys()))
             self.assertTrue(fqn.endswith("Foo.baz"))
             self.assertEqual(schemata[fqn], self.EXPECTED_DESCRIPTION | {"fqn": fqn})
+            self.assertEqual(foo.bar.parameter, foo.baz.parameter)
 
 
 class FloatParamCase(GenericBase.Cases):


### PR DESCRIPTION
Adds support for transitive rebinding of parameters.

If fragment A has two children, B and C, support already existed for overriding `C.my_param` to depend on `B.my_param` then `B.my_param` to depend on `A.my_param`. 

This PR lets you do it the other way around, giving the same final result but reversing the call order so you can first bind `B.my_param` to `A.my_param`, then `C.my_param` to `B.my_param`. 

We found this need pop up when wanting to bind parameters between subfragments at the same hierarchical level. 